### PR TITLE
Prep for release candidate v0.0.2

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: Reads plantum markups in markdown documentation, parses them  and inserts a link to render the svg|png|jpg representation
   entry: mdplantuml
   language: node
-  args: [--extension=png, --image-dir=./docs/assets/puml,  --prefix= ]    #types: ["markdown", "plantuml"]
+  args: [--extension=png, --image-dir=gen_docs/assets/puml,  --prefix= ]    #types: ["markdown", "plantuml"]
   files:  \.md$

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can define the hook in you `.pre-commit-config.yaml` file as follows:
 ```yaml
 repos:
   - repo: https://github.com/entrofi/pre-commit-md-plantuml-converter
-    rev: v0.0.1
+    rev: v0.0.2
     hooks:
       - id:  md_plantuml_converter
         args: [--extension=png, --image-dir=./docs/assets/puml,  --prefix= ]

--- a/pre_commit_md_plantuml_converter.sh
+++ b/pre_commit_md_plantuml_converter.sh
@@ -27,17 +27,56 @@ for i in "$@"; do
   esac
 done
 
-echo "FILE EXTENSION  = ${EXTENSION}"
-echo "IMAGE DIR       = ${IMAGE_DIR}"
-echo "PREFIX          = ${PREFIX}"
-echo "FILES"
-echo "$@"
-for filename in "$@"; do
-  echo "Current directory $(pwd)"
-  echo "Processing ${filename}"
-  fileContent=$(cat $filename)
-  if [ -z "${PREFIX}" ]; then
-      PREFIX="${filename}_"
+function debugScriptArgs {
+  if ! [[ -z "${DEBUG_VARS:-}" ]]; then
+    echo "==================================SCRIPT ARGS=================================="
+    echo "IMAGE EXTENSION = ${EXTENSION}"
+    echo "IMAGE DIR       = ${IMAGE_DIR}"
+    echo "PREFIX          = ${PREFIX}"
+    echo "FILES           = $(echo "$@")"
   fi
-  convert-plantuml "${fileContent}" "${EXTENSION}" "${IMAGE_DIR}" ${PREFIX} > "${filename}"
+}
+
+function debugFileVars {
+  if ! [[ -z "${DEBUG_VARS:-}" ]]; then
+      local -r currentFile="$1"
+      local -r prefixForImg="$2"
+      echo "============================================================================="
+      echo "Processing ${currentFile}"
+      echo "Current file              = ${filename}"
+      echo "Current file path         = ${FILE_PATH}"
+      echo "Current file base name    = ${FILE_BASE_NAME}"
+      echo "Current file extension    = ${FILE_EXT}"
+      echo "Current calculated prefix = ${prefixForImg}"
+      echo "Image dir                 = ${IMAGE_DIR}"
+      echo "Provided PREFIX           = ${PREFIX}"
+  fi
+}
+
+function prepareFileDetails {
+  local -r currentFile="$1"
+  local -r pickedFilePath="${currentFile%/*}"
+  FILE_PATH="${currentFile%/*}"
+  FILE_BASE_NAME="${currentFile##*/}"
+  FILE_NAME_PREFIX="${FILE_BASE_NAME%.*}"
+  FILE_EXT="${FILE_BASE_NAME##*.}"
+
+  [[ $currentFile == "${pickedFilePath}" ]] && FILE_PATH="" || FILE_PATH="${pickedFilePath:-}"
+}
+
+function getImagePrefix {
+  local -r candidatePrefix="$1"
+  local imagePrefixPrefix=""
+  [[ -z "${PREFIX}" ]] && imagePrefixPrefix="${candidatePrefix}_" || imagePrefixPrefix="${PREFIX}"
+  echo "${imagePrefixPrefix}"
+}
+
+debugScriptArgs "$@"
+
+for filename in "$@"; do
+  prepareFileDetails "${filename}"
+  prefixForImages=$(getImagePrefix "${FILE_NAME_PREFIX}")
+  fileContent=$(cat $filename)
+  debugFileVars "${filename}" "${prefixForImages}"
+  convert-plantuml "${fileContent}" "${EXTENSION}" "${FILE_PATH:-"."}" "${IMAGE_DIR}" ${prefixForImages} > "${filename}"
 done

--- a/src/collapsible-snippet.js
+++ b/src/collapsible-snippet.js
@@ -33,7 +33,8 @@ ${CollapsibleSnippet.#TPL_IMAGE_LINK_PLACE_HOLDER}
    */
   static makeCollapsible(plantumlMdSnippet) {
     const imageLinkMatcher = MdPumlMatchers.imageLinkMatcher;
-    let collapsible = plantumlMdSnippet;
+    imageLinkMatcher.lastIndex = 0;
+    let collapsible = plantumlMdSnippet.trim();
     if (plantumlMdSnippet.search(/(<details>)/) < 0) {
       collapsible = CollapsibleSnippet.#COLLAPSE_TPL;
       let imageLinkIndex;

--- a/src/convert-plantuml.js
+++ b/src/convert-plantuml.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
-const PlantumlSnippetConverter = require('../src/plantuml-snippet-converter');
+const PlantumlSnippetConverter = require('../src/plantuml-snippet-converter').PlantumlSnippetConverter;
+const MdPumlMatchers = require('./md-puml-matchers');
 const doc = `
 Usage:
-  convert-plantuml.js <markdownWithPlantuml> <extension> [<imagePath>]  [<imagePrefix>]
+  convert-plantuml.js <markdownWithPlantuml> <extension> <markdownFilePath> [<imagePath>]  [<imagePrefix>]
 Arguments:
   plantuUmlComment      The markdown comment string containing plantuml markup \`\`\`plantum \`\`\`
   extension             Image type extension e.g.: 'svg', 'png', 'jpg'
+  markdownFilePath      Relative path of the current markdown file
   imagePath             Save path for the generated images
   imagePrefix           A prefix to add to generated image filenames
 Example:
@@ -15,8 +17,9 @@ Example:
 const docopt = require('docopt').docopt;
 
 
-const convertPumlMarkup = (mdPumlSnippet, extension, imagePrefix, imagePath) => {
-  const mdPumlConverter = new PlantumlSnippetConverter(mdPumlSnippet, {extension, imagePath, imagePrefix});
+const convertPumlMarkup = (mdPumlSnippet, extension, markdownFilePath, imagePrefix, imagePath) => {
+  const mdPumlConverter = new PlantumlSnippetConverter(mdPumlSnippet,
+      {extension, workingDir: markdownFilePath, imagePath, imagePrefix});
   return mdPumlConverter.convert();
 };
 
@@ -25,9 +28,10 @@ const main = async (config) => {
   const extension = config['<extension>'];
   const prefix = config['<imagePrefix>'];
   const imagePath = config['<imagePath>'];
-  const pumlMdSnippetMatch = /(<details>\n([\S\s]*?<summary>.*\n{2}))?(`{3}plantuml\n@startuml)([\S\s]*?)(@enduml\n`{3}){1}(([\S\s]*?)((<\/details>\n)))?(\n+\!\[\]\(.*\))?/gm;
+  const markdownFilePath = config['<markdownFilePath>'];
+  const pumlMdSnippetMatch = MdPumlMatchers.resetAndGetMarkdownPlantumlSnippetMatcher();
   const reformattedMarkdown = markdown.replace(pumlMdSnippetMatch,
-      (s) => convertPumlMarkup(s, extension, prefix, imagePath));
+      (s) => convertPumlMarkup(s, extension, markdownFilePath, prefix, imagePath));
   return reformattedMarkdown;
 };
 

--- a/src/md-puml-matchers.js
+++ b/src/md-puml-matchers.js
@@ -23,11 +23,66 @@ class MdPumlMatchers {
   static imageLinkNameAndExtension = /(?<=\!\[.*\]\()(?<filePath>.*)(?<extension>\.[0-9a-z]+)(?=\))/gm;
 
   /**
+   *
+   * @return {RegExp} see {@link imageLinkNameAndExtension}
+   */
+  static resetAndGetImageLinkNameAndExtension() {
+    MdPumlMatchers.imageLinkNameAndExtension.lastIndex = 0;
+    return MdPumlMatchers.imageLinkNameAndExtension;
+  }
+
+  /**
+   * Matches file path, filename without extension and extension into dedicated groups
+   * @type {RegExp}
+   */
+  static imageLinkNamePathExtesionGroups = /(?<=\!\[\]\()(?<filePath>(.*\/)*)(?<filenamePrefix>.*)(?<extension>\.[0-9a-z]+)(?=\))/gm;
+
+  /**
+   *
+   * @return {RegExp} see {@link imageLinkNamePathExtesionGroups}
+   */
+  static resetAndGetImageLinkNamePathExtesionGroups() {
+    MdPumlMatchers.imageLinkNamePathExtesionGroups.lastIndex = 0;
+    return MdPumlMatchers.imageLinkNamePathExtesionGroups;
+  }
+
+  /**
      * Matches the sole filename (i.e. without extension) and the extension of the file in <filePath> and <extension>
      *     regex named groups. Note that it does not look up for filename validity.
      * @type {RegExp}
      */
   static imageNameAndExtension = /(?<filePath>.*)(?<extension>\.[0-9a-z]+){1}/gm;
+
+  /**
+   *
+   * @return {RegExp} see {@link imageNameAndExtension}
+   */
+  static resetAndGetImageNameExtension() {
+    MdPumlMatchers.imageNameAndExtension.lastIndex = 0;
+    return MdPumlMatchers.imageNameAndExtension;
+  }
+
+  /**
+   * Matches plantuml snippets in markdowns either in the form of a collapsible or plain with groups:
+   * <ol>
+   *     <li>detailsBeginning</li>
+   *     <li>plantumlSnippet</li>
+   *     <li>linkPlain: if there is any</li>
+   *     <li>detailsEnd</li>
+   *     <li>linkDetails: if there is any</li>
+   * </ol>
+   * @type {RegExp}
+   */
+  static markdownPlantumlSnippetMatcher = /((?<detailsBeginning>(<details>\s*<summary>)([\s\S]*?(?=<\/summary)(<\/summary>)))([\s\S]*?(?<!`{3}plantuml)))?(?<plantumlSnippet>(`{3}plantuml)[\s\S]*?(@startuml)[\s\S]*?(?=`{3})(`{3})){1}(([\s]*?(?=<\/details))(?<detailsEnd>(<\/details>)))?(\s)*(?<link>(\!\[.*\]\(.*\)))?/gm;
+
+  /**
+   *
+   * @return {RegExp} see {@link markdownPlantumlSnippetMatcher}
+   */
+  static resetAndGetMarkdownPlantumlSnippetMatcher() {
+    MdPumlMatchers.markdownPlantumlSnippetMatcher.lastIndex = 0;
+    return MdPumlMatchers.markdownPlantumlSnippetMatcher;
+  }
 }
 
 module.exports = MdPumlMatchers;

--- a/src/regex-utils.js
+++ b/src/regex-utils.js
@@ -1,0 +1,15 @@
+/**
+ *
+ */
+class RegexUtils {
+  /**
+     * Escapes regular expression special characters in a s tring
+     * @param {string} string
+     * @return {*}
+     */
+  static escapeRegExChars(string) {
+    return string.replace(/[\\{}()|[\].*+?^$]/g, '\\$&');
+  }
+}
+
+module.exports = RegexUtils;

--- a/test/collapsible-snippet.test.js
+++ b/test/collapsible-snippet.test.js
@@ -11,13 +11,13 @@ ${content}
 ${appenditure}
 `;
 describe( 'Generates a collapsibe snippet', () => {
-  const sampleContent = `\`\`\`plantuml
+  const sampleContent = `\n\`\`\`plantuml
 @startuml
 :2. Hello world*!!!!*;
 :This is defined on
 several **lines**;
 @enduml
-\`\`\``;
+\`\`\`\n\n`;
 
   const sampleAppenditure = `![](output_1658728903544.png)`;
 
@@ -27,7 +27,8 @@ several **lines**;
     const appenditure = sampleAppenditure;
     const inputPumlSnippet = `${content}\n${appenditure}`;
 
-    expect(CollapsibleSnippet.makeCollapsible(inputPumlSnippet)).toBe(expectedCollapsibleTpl(content, appenditure));
+    expect(CollapsibleSnippet.makeCollapsible(inputPumlSnippet))
+        .toBe(expectedCollapsibleTpl(content.trim(), appenditure));
   });
 
   test('makeCollapsible should generate the correct output even with additional \\n chars', () => {
@@ -35,6 +36,7 @@ several **lines**;
     const appenditure = sampleAppenditure;
     const inputPumlSnippet = `${content}\n\n\n${appenditure}\n\n\n\r`;
 
-    expect(CollapsibleSnippet.makeCollapsible(inputPumlSnippet)).toBe(expectedCollapsibleTpl(content, appenditure));
+    expect(CollapsibleSnippet.makeCollapsible(inputPumlSnippet))
+        .toBe(expectedCollapsibleTpl(content.trim(), appenditure));
   });
 });

--- a/test/md-puml-matchers.test.js
+++ b/test/md-puml-matchers.test.js
@@ -1,0 +1,64 @@
+const MdPumlMatchers = require('../src/md-puml-matchers');
+const PumlMdTestUtil = require('./puml-md-snippet-test-utils');
+
+
+describe( 'Markdown plantuml matchers', () => {
+  test('Should match path, filename and extension in groups', () => {
+    const samplePath = '/abce/dire.ctory/at somewhere b/';
+    const samplePathWithDot = `.${samplePath}`;
+    const filename = 'filename';
+    const extension = '.png';
+
+    const fullNameLink = `![](${samplePath}${filename}${extension})`;
+    const fullNameWithDotLink = `![](${samplePathWithDot}${filename}${extension})`;
+
+    let imageLinkNamePathExtesionGroups = MdPumlMatchers.resetAndGetImageLinkNamePathExtesionGroups();
+    const fullNameMatch = imageLinkNamePathExtesionGroups.exec(fullNameLink);
+    expect(fullNameMatch.groups).toBeTruthy();
+    expect(fullNameMatch.groups.filePath).toBe(samplePath);
+    expect(fullNameMatch.groups.filenamePrefix).toBe(filename);
+    expect(fullNameMatch.groups.extension).toBe(extension);
+
+    imageLinkNamePathExtesionGroups = MdPumlMatchers.resetAndGetImageLinkNamePathExtesionGroups();
+    const fullNameWithDotMatch = imageLinkNamePathExtesionGroups.exec(fullNameWithDotLink);
+    expect(fullNameWithDotMatch.groups).toBeTruthy();
+    expect(fullNameWithDotMatch.groups.filePath).toBe(samplePathWithDot);
+    expect(fullNameWithDotMatch.groups.filenamePrefix).toBe(filename);
+    expect(fullNameWithDotMatch.groups.extension).toBe(extension);
+  });
+
+  test('markdownPlantumlSnippetMatcher should match plain plantuml snippet with link', () => {
+    const snippetWithLink = PumlMdTestUtil.getPlainSnippetWithLink(
+        PumlMdTestUtil.plainSnippet,
+        PumlMdTestUtil.imageLinkHardCode);
+    const match = MdPumlMatchers.resetAndGetMarkdownPlantumlSnippetMatcher().exec(snippetWithLink);
+    expect(match).toBeTruthy();
+    expect(match[0]).toBe(snippetWithLink.trim());
+    expect(match.groups.link).toBe(PumlMdTestUtil.imageLinkHardCode);
+    expect(match.groups.plantumlSnippet).toBe(PumlMdTestUtil.plainSnippet);
+  });
+
+  test('markdownPlantumlSnippetMatcher should match plain plantuml snippet without link', () => {
+    const snippetWithoutLink = PumlMdTestUtil.getPlainSnippetWithLink(
+        PumlMdTestUtil.plainSnippet,
+        undefined);
+    const match = MdPumlMatchers.resetAndGetMarkdownPlantumlSnippetMatcher().exec(snippetWithoutLink);
+    expect(match).toBeTruthy();
+    expect(match[0]).toBe(snippetWithoutLink.trimStart());
+    expect(match.groups.link).toBeFalsy();
+    expect(match.groups.plantumlSnippet).toBe(PumlMdTestUtil.plainSnippet);
+  });
+
+  test('markdownPlantumlSnippetMatcher should match plantuml snippet with details', () => {
+    const snippetWithoutLink = PumlMdTestUtil.getSnippetWithDetails(
+        PumlMdTestUtil.plainSnippet,
+        PumlMdTestUtil.imageLinkHardCode);
+    const match = MdPumlMatchers.resetAndGetMarkdownPlantumlSnippetMatcher().exec(snippetWithoutLink);
+    expect(match).toBeTruthy();
+    expect(match[0]).toBe(snippetWithoutLink.trim());
+    expect(match.groups.link).toBe(PumlMdTestUtil.imageLinkHardCode);
+    expect(match.groups.detailsBeginning).toBeTruthy();
+    expect(match.groups.detailsEnd).toBeTruthy();
+    expect(match.groups.plantumlSnippet).toBe(PumlMdTestUtil.plainSnippet);
+  });
+});

--- a/test/plantuml-snippet-converter.test.js
+++ b/test/plantuml-snippet-converter.test.js
@@ -1,4 +1,5 @@
-const PlantumlSnippetConverter = require('../src/plantuml-snippet-converter');
+const PlantumlSnippetConverter = require('../src/plantuml-snippet-converter').PlantumlSnippetConverter;
+const ImageNameData = require('../src/plantuml-snippet-converter').ImageNameData;
 const fs = require('fs');
 
 const sampleNoLinkInputSnippet = `\`\`\`plantuml
@@ -10,8 +11,18 @@ else
 @enduml
 \`\`\``;
 
-const sampleImageFilename = 'd723db8c7063fdd0cc764a8f46fbd3ad';
-const expectedImagePathWith = (extension, imageName, savePath) => `${savePath? savePath + '/': ''}${imageName}.${extension}`;
+const sampleImgFilenamePrefix = 'd723db8c7063fdd0cc764a8f46fbd3ad';
+const expectedImagePathWith = (extension, imageFileNamePrefix, savePath) => `${savePath? savePath + '/': ''}${imageFileNamePrefix}.${extension}`;
+
+const getImageNameData = (filenamePrefix, imageDir, relativeToRootPath, relativeToWorkDirPath, extension) => {
+  const imageFilename = `${filenamePrefix}.${extension}`;
+  return new ImageNameData(filenamePrefix, imageDir, `${relativeToRootPath.replace(/\/$/, '')}/${imageFilename}`,
+      `${relativeToWorkDirPath.replace(/\/$/, '')}/${imageFilename}`, `${extension}`, `${imageFilename}`);
+};
+
+const getImageNameDataWith = (imageDir, extension, relativeToRootPath, relativeToWorkDirPath ) => {
+  return getImageNameData(sampleImgFilenamePrefix, imageDir, relativeToRootPath, relativeToWorkDirPath, extension);
+};
 
 const sampleMDOutputTplWith = (extension, imageName, savePath) => `
 <details>
@@ -28,34 +39,41 @@ else
 
 </details>
 
-![](${expectedImagePathWith(extension, imageName, savePath)})`;
+![](${expectedImagePathWith(extension, imageName, savePath)})\n\n`;
 
-const testImageSavePath = './.tmp/assets/puml';
+const testImagePath = '.tmp/assets/puml';
 
 const snippetConverterPNG = new PlantumlSnippetConverter(sampleNoLinkInputSnippet,
-    {extension: 'png', imagePath: testImageSavePath});
+    {extension: 'png', workingDir: '.', imagePath: testImagePath});
 const snippetConverterEPS = new PlantumlSnippetConverter(sampleNoLinkInputSnippet,
-    {extension: 'eps', imagePath: testImageSavePath});
+    {extension: 'eps', workingDir: '.', imagePath: testImagePath});
 const snippetConverterSVG = new PlantumlSnippetConverter(sampleNoLinkInputSnippet,
-    {extension: 'svg', imagePath: testImageSavePath});
+    {extension: 'svg', workingDir: '.', imagePath: testImagePath});
 
 describe('PlantumlSnippetConverter tests', () => {
   afterAll(() => {
-    fs.rmSync(testImageSavePath, {recursive: true, force: true});
+    fs.rmSync(testImagePath, {recursive: true, force: true});
     fs.rmSync();
   });
 
-  test('Converts markdown plantuml snippet with save path', () => {
-    expect(snippetConverterPNG.convert()).toBe(sampleMDOutputTplWith('png', sampleImageFilename, testImageSavePath));
+  test('Converts markdown plantuml snippet with image path', () => {
+    expect(snippetConverterPNG.convert()).toBe(sampleMDOutputTplWith('png', sampleImgFilenamePrefix, `./${testImagePath}`));
   });
 
-  test('Converts markdown plantuml snippet without save path', () => {
+  test('Converts markdown plantuml snippet with image path in a sub directory', () => {
+    const imagePrefix = 'test';
+    const snippetConverter = new PlantumlSnippetConverter(sampleNoLinkInputSnippet,
+        {extesion: 'png', workingDir: 'subdir/', imagePath: testImagePath, imagePrefix: 'test'});
+    expect(snippetConverter.convert()).toBe(sampleMDOutputTplWith('png', `${imagePrefix}${sampleImgFilenamePrefix}`, `./${testImagePath}`));
+  });
+
+  test('Converts markdown plantuml snippet without image path', () => {
     const snippetConverterWOPath = new PlantumlSnippetConverter(sampleNoLinkInputSnippet,
-        {extension: 'png'});
-    expect(snippetConverterWOPath.convert()).toBe(sampleMDOutputTplWith('png', sampleImageFilename));
+        {extension: 'png', workingDir: '.'});
+    expect(snippetConverterWOPath.convert()).toBe(sampleMDOutputTplWith('png', sampleImgFilenamePrefix, '.'));
   });
 
-  test('Converts markdown plantuml snippet without save path for', () => {
+  test('Converts markdown plantuml snippet without save path for snippet with existing image', () => {
     const trickySnippet = `
 \`\`\`plantuml
 @startuml
@@ -64,7 +82,7 @@ if (color?) is (<color:red>red) then
 else
 :print not red;
 @enduml
-\`\`\`
+\`\`\`\n
 ![](output_1658728903544.png)
 
 `;
@@ -75,26 +93,54 @@ else
 
   test('generateImage() generates a png image with correct path', () => {
     const imagePath = snippetConverterPNG.generateImage();
-    console.log(`image path: ${imagePath}`);
-    expect(imagePath).toBe(expectedImagePathWith('png', sampleImageFilename, testImageSavePath));
+    expect(imagePath).toMatchObject(getImageNameDataWith(`./${testImagePath}`, 'png', `./${testImagePath}`, `./${testImagePath}`));
   });
 
   test('generateImage() generates a eps image with correct path', () => {
     const imagePath = snippetConverterEPS.generateImage();
-    console.log(`image path: ${imagePath}`);
-    expect(imagePath).toBe(expectedImagePathWith('eps', sampleImageFilename, testImageSavePath));
+    expect(imagePath).toMatchObject(getImageNameDataWith(`./${testImagePath}`, 'eps', `./${testImagePath}`, `./${testImagePath}`));
   });
 
   test('generateImage() generates a svg image with correct path', () => {
     const imagePath = snippetConverterSVG.generateImage();
-    console.log(`image path: ${imagePath}`);
-    expect(imagePath).toBe(expectedImagePathWith('svg', sampleImageFilename, testImageSavePath));
+    expect(imagePath).toMatchObject(getImageNameDataWith(`./${testImagePath}`, 'svg', `./${testImagePath}`, `./${testImagePath}`));
   });
 
 
   test('Should get the existing path reference in the snippet', () => {
-    const plantUmlWithPngLink = sampleMDOutputTplWith('png', 'myDummy/path');
+    const imageNamePrefix = 'dummyImage';
+    const imagePath = `myDummy/path/imagedir/`;
+    const plantUmlWithPngLink = sampleMDOutputTplWith('png', `${imagePath}${imageNamePrefix}`);
     expect(PlantumlSnippetConverter.extractPathFromRefLink(plantUmlWithPngLink))
-        .toBe(expectedImagePathWith('png', 'myDummy/path'));
+        .toMatchObject(getImageNameData(imageNamePrefix, imagePath, imagePath, imagePath, 'png' ));
+  });
+
+  test('Should replace relative path references correctly', () => {
+    const snippetWithRelImagePath = `# A collapsible section with markdown\n<details>\n  <summary>Click to expand the puml definition!</summary>\n\n\`\`\`plantuml\n@startuml\nHasan -> Bob: Esenlikler Bob cugum\nBob --> Hasan: How are you\nBob --> Alice: Hello Alice\n\nAlice -> Bob: Another authentication Request\nAlice <-- Bob: Another authentication Response\n@enduml\n\`\`\`\n</details>\n\n![](./docs/assets/puml/README_b8115805a361deae478ef76dc2e0ab32.png)\n\n`;
+    const snippetConverterWOPath = new PlantumlSnippetConverter(snippetWithRelImagePath,
+        {extension: 'png', workingDir: '.', imagePath: './docs/assets/puml', imagePrefix: 'README_'});
+    expect(snippetConverterWOPath.convert()).toBe(snippetWithRelImagePath);
+  });
+
+  test('mergePathSegments should merge correctly', () => {
+    const inputs = [
+      {pioneer: '.', follower: '', expectedResult: '.'},
+      {pioneer: './', follower: '', expectedResult: './'},
+      {pioneer: '.', follower: undefined, expectedResult: '.'},
+      {pioneer: '.', follower: '/', expectedResult: `./`},
+      {pioneer: './', follower: '/', expectedResult: `./`},
+      {pioneer: './', follower: '/abc/def', expectedResult: `./abc/def`},
+      {pioneer: 'pioneer/', follower: '/abc/def', expectedResult: `pioneer/abc/def`},
+      {pioneer: '.pioneer/', follower: '/abc/def', expectedResult: `.pioneer/abc/def`},
+      {pioneer: '/pioneer/', follower: '/abc/def', expectedResult: `/pioneer/abc/def`},
+      {pioneer: './pioneer/', follower: '/abc/def', expectedResult: `./pioneer/abc/def`},
+      {pioneer: './pioneer/', follower: './abc/def', expectedResult: `./pioneer/abc/def`},
+      {pioneer: '/pioneer/', follower: undefined, expectedResult: `/pioneer/`},
+      {pioneer: undefined, follower: undefined, expectedResult: undefined},
+      {pioneer: undefined, follower: 'abc', expectedResult: `abc`},
+    ];
+    inputs.forEach((i) => {
+      expect(PlantumlSnippetConverter.mergePathSegments(i.pioneer, i.follower)).toBe(i.expectedResult);
+    });
   });
 });

--- a/test/puml-md-snippet-test-utils.js
+++ b/test/puml-md-snippet-test-utils.js
@@ -1,0 +1,20 @@
+const CollapsibleSnippet = require('../src/collapsible-snippet');
+
+const plainSnippet = `\`\`\`plantuml\n@startuml\n\nstart\n\nif (3. Graphviz installed?) then (yes)\n  :process all\\ndiagrams;\nelse (no)\n  :process only\n  __sequence__ and __activity__ diagrams;\nendif\n\nstop\n\n@enduml\n\`\`\``;
+const imageLinkHardCode = '![](./gen_docs/assets/puml/test_3333638a3649518f7ab5edab88b22c16.png)';
+
+const getPlainSnippetWithLink = (plainSnippet, imageLink) => {
+  return `${plainSnippet}${imageLink ? '\n' + imageLink : ''}`;
+};
+
+const getSnippetWithDetails = (plainSnippet, imageLink) => {
+  const snippetWithLink = getPlainSnippetWithLink(plainSnippet, imageLink);
+  return CollapsibleSnippet.makeCollapsible(snippetWithLink);
+};
+
+module.exports = {
+  plainSnippet,
+  imageLinkHardCode,
+  getPlainSnippetWithLink,
+  getSnippetWithDetails,
+};


### PR DESCRIPTION
Add additoinal options and fix global snippet matcher on convert-plantuml.js

Prep for release candidate:

-Modify default image-dir argument for the hook setup

-Add reset option and add tests for collapsible-snippet.js

-Add resetted getters for /gm matching regexes and add tests

-Update READ.me example for the next version
-Fine tune regexes and path handling
-Add more tests.